### PR TITLE
feat: add server test setup with jest

### DIFF
--- a/server/__tests__/health.test.ts
+++ b/server/__tests__/health.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import app from '../index';
+
+describe('GET /health', () => {
+  it('returns ok status', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -94,19 +94,23 @@ io.on('connection', (socket) => {
   });
 });
 
-// Start the server
-const PORT = process.env.PORT || 5000;
-httpServer.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+// Start the server and connect to MongoDB only outside of tests
+if (process.env.NODE_ENV !== 'test') {
+  const PORT = process.env.PORT || 5000;
+  httpServer.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
 
-// Connect to MongoDB
-const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/qr-restaurant';
-mongoose.connect(MONGODB_URI)
-  .then(() => {
-    console.log('Connected to MongoDB');
-  })
-  .catch((error) => {
-    console.error('MongoDB connection error:', error);
-    console.log('Server will continue running without MongoDB connection');
-  }); 
+  const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/qr-restaurant';
+  mongoose
+    .connect(MONGODB_URI)
+    .then(() => {
+      console.log('Connected to MongoDB');
+    })
+    .catch((error) => {
+      console.error('MongoDB connection error:', error);
+      console.log('Server will continue running without MongoDB connection');
+    });
+}
+
+export default app;

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
     "start": "ts-node index.ts",
     "dev": "nodemon --exec ts-node index.ts",
     "build": "tsc",
-    "seed": "ts-node scripts/seedDatabase.ts"
+    "seed": "ts-node scripts/seedDatabase.ts",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -30,6 +31,11 @@
     "@types/node": "^18.15.11",
     "nodemon": "^2.0.22",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "@types/jest": "^29.5.5",
+    "@types/supertest": "^2.0.12",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest config and health-check test for server
- export Express app and avoid server start in tests
- add npm test script and testing dependencies

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b208f2356c83259608b7e0726f723a