### PR TITLE
chore: set unified port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 # Build TypeScript code
 RUN npm run build
 
-# Expose port 5000
-EXPOSE 5000
+# Expose port 5001
+EXPOSE 5001
 
 CMD ["npm", "start"] 

--- a/config/default.ts
+++ b/config/default.ts
@@ -1,5 +1,5 @@
 export default {
-  port: process.env.PORT || 5000,
+  port: process.env.PORT || 5001,
   mongoUri: process.env.MONGO_URI || 'mongodb://localhost:27017/qr-restaurant',
   jwtSecret: process.env.JWT_SECRET || 'your-secret-key',
   corsOrigin: process.env.CORS_ORIGIN || 'http://localhost:3000',

--- a/server/.env
+++ b/server/.env
@@ -8,4 +8,4 @@ MONGODB_URI=mongodb://localhost:27017/qr-restaurant
 CORS_ORIGIN=http://localhost:3000
 
 # Optional: JWT Secret (if implementing authentication later)
-JWT_SECRET=your-secret-key 
+JWT_SECRET=your-secret-key

--- a/server/index.ts
+++ b/server/index.ts
@@ -95,7 +95,7 @@ io.on('connection', (socket) => {
 });
 
 // Start the server
-const PORT = process.env.PORT || 5000;
+const PORT = process.env.PORT || 5001;
 httpServer.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- set default server port to 5001 in env and config
- expose port 5001 in Dockerfile
- default to port 5001 when starting server

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm run build` (server) *(fails: Cannot find module '../data/sampleMenu')*
- `npm test -- --watchAll=false` (client) *(fails: Cannot find module '@chakra-ui/utils/context')*

------
https://chatgpt.com/codex/tasks/task_e_68b20d2c53a88325b23c81cdb31b4d49